### PR TITLE
meta.html: Use name=description instead of just itemprop

### DIFF
--- a/layouts/partials/header/meta.html
+++ b/layouts/partials/header/meta.html
@@ -76,6 +76,7 @@
 
 {{- /* Facebook Page Admin ID for Domain Insights */}}
 {{- with .Site.Social.facebook_admin }}<meta property="fb:admins" content="{{ . }}" />{{ end }}
+{{ with .Description }}<meta name="description" content="{{ . }}" />{{ end }}
 <meta itemprop="name" content="{{ $seoTitle }}">
 <meta itemprop="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
 


### PR DESCRIPTION
See https://developers.google.com/search/docs/crawling-indexing/special-tags