### PR TITLE
mailchimp-page.html: Use nav == statecollege instead of hardcoding

### DIFF
--- a/content/newsletters/pennstatealert/_index.md
+++ b/content/newsletters/pennstatealert/_index.md
@@ -13,6 +13,7 @@ sort-by = "month"
 
 [cascade]
 image = "2023/02/01hx-t3ph-mmqa-hkt2.jpeg"
+nav = "statecollege"
 +++
 Sign up for **Penn State Alerts**, and be the first to know about our latest investigative and accountability journalism about Penn State University by by Spotlight PA’s State College regional bureau.
 

--- a/content/newsletters/talkofthetown/_index.md
+++ b/content/newsletters/talkofthetown/_index.md
@@ -11,6 +11,7 @@ sort-by = "month"
 
 [cascade]
 image = "2022/06/01hb-484c-z2hw-3tfc.jpeg"
+nav = "statecollege"
 +++
 Sign up for **Talk of the Town**, a free weekly newsletter every Thursday with top news and notes for North-Central PA by Spotlight PA’s State College regional bureau.
 

--- a/layouts/_default/mailchimp-page.html
+++ b/layouts/_default/mailchimp-page.html
@@ -16,9 +16,7 @@
 {{ define "header" }}
   <header data-ga-category="header">
     {{ block "nav" . }}
-      {{ $tott := site.GetPage "/newsletters/talkofthetown/_index.md" }}
-      {{ $isSCpage := .Page.InSection $tott }}
-      {{ if $isSCpage }}
+      {{ if eq .Params.nav "statecollege" }}
         {{ partial "tw/nav-sc.html" . }}
       {{ else }}
         {{ partial "tw/nav.html" . }}

--- a/layouts/_default/news.html
+++ b/layouts/_default/news.html
@@ -9,7 +9,11 @@
 {{ define "header" }}
   <header data-ga-category="header">
     {{ block "nav" . }}
-      {{ partialCached "tw/nav.html" . }}
+      {{ if eq .Params.nav "statecollege" }}
+        {{ partial "tw/nav-sc.html" . }}
+      {{ else }}
+        {{ partial "tw/nav.html" . }}
+      {{ end }}
     {{ end }}
     {{ block "banner" . }}
       {{ if .Param "banner-active" }}
@@ -99,6 +103,7 @@
 {{ define "svg-resources" }}
   {{ $svgs := dict
     "banner-svg" "/img/logos/banner-default-on-trans.svg"
+    "banner-state-college-svg" "/img/logos/banner-state-college.svg"
     "bars-svg" "@fontawesome/solid/bars.svg"
     "calendar-svg" "@fontawesome/regular/calendar-check.svg"
     "close-svg" "@fontawesome/solid/circle-xmark.svg"


### PR DESCRIPTION
This fixes the nav on PS Alerts, and we can roll out this pattern more down the line.