### PR TITLE
Promos: Check modal is on page before saying it should be triggered

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -41,14 +41,10 @@
     data-page-cat="{{ $pageCat }}"
     {{ block `body-attributes` . }}{{ end }}
   >
-    {{ if .Param "takeover-active" }}
-      {{ partial "tw/modal-takeover.html" ( dict
-        "filename" "2023/08/01jd-w2vj-77eb-3dp1.jpeg"
-        "hed" "Time is running out and we need your help"
-        "dek" "Only a few hours remain for your gift to Spotlight PA to be DOUBLED. Contribute now and ensure our trusted, nonpartisan investigative journalism can continue."
-        "link" "https://spotlightpa.fundjournalism.org/statecollege/?campaign=701Dn000000YqKfIAK"
-        )
-      }}
+    {{ if .Param "modal-exclude" | not }}
+      {{ if .Param "takeover-active" }}
+        {{ partial "tw/modal-takeover.html" . }}
+      {{ end }}
     {{ end }}
     {{ block "header" . }}
       <header data-ga-category="header">

--- a/layouts/partials/tw/modal-newsletter-sc.html
+++ b/layouts/partials/tw/modal-newsletter-sc.html
@@ -112,10 +112,7 @@
             class="flex-grow text-s-6 hover:underline"
             aria-label="close"
             type="button"
-            @click="
-                $dispatch('x-form-submit', 'newsletters:seenit:submit');
-                isOpen = false
-              "
+            @click="seenIt()"
           >
             I’m already a subscriber
           </button>

--- a/layouts/partials/tw/modal-ribbon.html
+++ b/layouts/partials/tw/modal-ribbon.html
@@ -5,6 +5,7 @@
 
 
 <div
+  data-modal-kind="newsletter"
   class="fixed inset-0 z-20 overflow-y-scroll"
   data-ga-category="modal:newsletter:multi"
   x-data="modal"
@@ -203,10 +204,7 @@
               class="flex-initial py-3 pr-5 text-black underline md:mr-5"
               aria-label="close"
               type="button"
-              @click="
-              $dispatch('x-form-submit', 'newsletters:seenit:submit');
-              isOpen = false
-            "
+              @click="seenIt()"
             >
               I’m already a subscriber
             </button>

--- a/layouts/partials/tw/modal-sticky.html
+++ b/layouts/partials/tw/modal-sticky.html
@@ -7,6 +7,7 @@
 {{ $height := 0 }}
 {{ $bgColor := "#000" }}
 <section
+  data-modal-kind="sticky"
   class="max-w-screen fixed bottom-0 right-0 z-10"
   x-data="sticky"
   x-show="isOpen"

--- a/layouts/partials/tw/modal-takeover.html
+++ b/layouts/partials/tw/modal-takeover.html
@@ -1,11 +1,12 @@
-{{ $imagename := .filename }}
-{{ $hed := .hed }}
-{{ $dek := .dek }}
-{{ $link := .link }}
+{{ $imagename := page.Param "takeover-image" }}
+{{ $hed := page.Param "takeover-hed" }}
+{{ $dek := page.Param "takeover-dek" }}
+{{ $link := page.Param "takeover-link" }}
 
 
 <div x-data x-intersect.once="$dispatch('open-takeover')"></div>
 <section
+  data-modal-kind="takeover"
   data-ga-category="modal:takeover"
   x-intersect.once="show()"
   x-cloak

--- a/src/enhancements/modal.js
+++ b/src/enhancements/modal.js
@@ -1,5 +1,9 @@
 import { reportView } from "../utils/google-analytics.js";
-import { modalKind, recordModalNewsletterView } from "../utils/metrics.js";
+import {
+  modalKind,
+  recordModalNewsletterView,
+  recordNewsletterSignup,
+} from "../utils/metrics.js";
 
 export default function modal() {
   return {
@@ -23,6 +27,11 @@ export default function modal() {
     show() {
       if (modalKind !== "newsletter") return;
       this.isOpen = true;
+    },
+
+    seenIt() {
+      recordNewsletterSignup();
+      this.isOpen = false;
     },
   };
 }

--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -60,7 +60,6 @@ if (loadDate(SIGNED_UP_FOR_NEWSLETTER_KEY)) {
 
 storeItem(PRIOR_FUNNEL_STATUS_KEY, funnelStatus);
 
-// eslint-disable-next-line no-unused-vars
 let shouldShowModalNewsletter = (() => {
   // Does this page even have a newsletter to pop up?
   if (!document.querySelector("[data-modal-kind=newsletter]")) {

--- a/src/utils/metrics.js
+++ b/src/utils/metrics.js
@@ -62,6 +62,10 @@ storeItem(PRIOR_FUNNEL_STATUS_KEY, funnelStatus);
 
 // eslint-disable-next-line no-unused-vars
 let shouldShowModalNewsletter = (() => {
+  // Does this page even have a newsletter to pop up?
+  if (!document.querySelector("[data-modal-kind=newsletter]")) {
+    return false;
+  }
   if (onTestNewsletterPage) {
     return true;
   }
@@ -79,6 +83,10 @@ let shouldShowModalNewsletter = (() => {
 })();
 
 let shouldShowModalTakeover = (() => {
+  // Does this page even have a takeover to pop up?
+  if (!document.querySelector("[data-modal-kind=takeover]")) {
+    return false;
+  }
   if (onTestNewsletterPage) {
     return true;
   }
@@ -95,7 +103,9 @@ export let modalKind = (() => {
   if (shouldShowModalTakeover) {
     return "takeover";
   }
-  // Disable newsletter kind for now
+  if (shouldShowModalNewsletter) {
+    return "newsletter";
+  }
   return "sticky";
 })();
 


### PR DESCRIPTION
- Let Almanack overwrite properties of takeover
- Fix a bug with recording subscriber status when clicking "already a member"