### PR TITLE
Revert "google-analytics.js: Add GA4 hacky classes"

### DIFF
--- a/src/utils/google-analytics.js
+++ b/src/utils/google-analytics.js
@@ -67,26 +67,9 @@ function buildActionParams(el) {
   ];
 }
 
-function toggleGA4Classes(el, action, params) {
-  if (!el) return;
-  // Remove existing classes
-  let remove = Array.from(el.classList).filter((name) =>
-    name.startsWith("ga:")
-  );
-  for (let name of remove) {
-    el.classList.remove(name);
-  }
-  // Hack: Add dummy classes with ga:whatever so GA4 can search for them
-  el.classList.add(`ga:action:${action}`);
-  for (let [param, value] of Object.entries(params)) {
-    el.classList.add(`ga:${param}:${value}`);
-  }
-}
-
 function buildAndReport(el, action = "", overrides = {}) {
   let [elAction, params] = buildActionParams(el);
   callAnalytics(action || elAction, { ...params, ...overrides });
-  toggleGA4Classes(el, action || elAction, { ...params, ...overrides });
 }
 
 function normalizeLink(target) {


### PR DESCRIPTION
This did not work in production.

This reverts commit d72f62b29b46cba79cb00b9561df68ee06046a19.