### PR TITLE
tw/featured: Don't lazy load the featured image

### DIFF
--- a/layouts/partials/tw/featured.html
+++ b/layouts/partials/tw/featured.html
@@ -21,6 +21,7 @@
   "heightRatio" 9
   "widths" (slice 528 1056 1280)
   "sizeHint" "(min-width: 1080px) 528px, (min-width: 850px) 40vw, 90vw"
+  "eager" true
 }}
 
 {{ partial "tw/thumb-h-item.html" (dict


### PR DESCRIPTION
I was looking at https://pagespeed.web.dev and it mentioned that we're lazy loading the main image on the homepage.