### PR TITLE
promo-contact-form: Fix default form name

### DIFF
--- a/layouts/shortcodes/featured/promo-contact-form.html
+++ b/layouts/shortcodes/featured/promo-contact-form.html
@@ -39,7 +39,7 @@
 {{ $idSubject := partial "helper/new-id" . }}
 {{ $idBody := partial "helper/new-id" . }}
 {{ $idAnonymous := partial "helper/new-id" . }}
-{{ $formName := .Get "formName" | default "Contact Page" }}
+{{ $formName := .Get "formName" | default "contact-page" }}
 {{ $hed := .Get "hed" }}
 {{ $dek := .Get "dek" }}
 {{ $recipient := .Get "recipient" }}


### PR DESCRIPTION
Form responses seem to be going to the wrong place.