### PR TITLE
hidden.html: Include timestamp

### DIFF
--- a/layouts/partials/newsletter/hidden.html
+++ b/layouts/partials/newsletter/hidden.html
@@ -18,3 +18,10 @@
 </div>
 <!-- Shibboleth field: server will reject message if blank -->
 <input type="hidden" x-data :name="'shibboleth'" :value="'PA Rocks!'" />
+<!-- Shibboleth field: server will reject message if too old -->
+<input
+  type="hidden"
+  x-data
+  :name="'shibboleth_timestamp'"
+  :value="new Date().toISOString()"
+/>


### PR DESCRIPTION
Some spam is getting past the Shibboleth filter. Let's add a timestamp so they can't just submit the same thing every time.