### PR TITLE
hidden.html: Don't send blank timestamp

### DIFF
--- a/layouts/partials/newsletter/hidden.html
+++ b/layouts/partials/newsletter/hidden.html
@@ -23,6 +23,6 @@
   type="hidden"
   x-data="{ humanLike: false }"
   x-init="setTimeout(()=>{ humanLike = true }, 15000)"
-  :name="'shibboleth_timestamp'"
+  :name="humanLike? 'shibboleth_timestamp': ''"
   :value="humanLike? new Date().toISOString(): ''"
 />


### PR DESCRIPTION
This doesn't really matter but it will make the error logs from bots easier to read.