### PR TITLE
Requested updates for newsletter page

### DIFF
--- a/content/newsletters/_index.md
+++ b/content/newsletters/_index.md
@@ -11,6 +11,6 @@ aliases = ["/newsletters/covid/","/newsletters/covid-alerts-manage/"]
 paginate = 60
 +++
 
-### Get the best news from across PA straight to your inbox
+## Get the best news from across PA straight to your inbox
 
 Select any of the free newsletters below and enter your information to stay informed on the most important issues in our state.

--- a/content/newsletters/centredocumenters/_index.md
+++ b/content/newsletters/centredocumenters/_index.md
@@ -4,14 +4,14 @@ image-size = "inline"
 published = 2020-09-03T01:14:40.334Z
 title = "Sign up for Centre Documenters"
 description = "Sign up for Centre Documenters, a free biweekly newsletter"
-blurb = "Every Thursday, you’ll get exclusive, behind-the-scenes looks at our reporting, important updates from the state Capitol, and a roundup of the best accountability journalism from across Pennsylvania."
-linktitle = "Centre County Documenters"
+blurb = "Critical information and decisions from public meetings in Benner, College, Gregg, Halfmoon, Snow Shoe, and Spring Townships documented by trained students and local residents."
+linktitle = "Centre Documenters"
 modal-exclude = true
 layout = "news"
 sort-by = "month"
 occurence = "First and Third Monday"
 url = "/centredocumenters/"
-
+weight = 5
 [cascade]
 image = "2023/11/01jm-5423-9jym-wv30.webp"
 +++

--- a/content/newsletters/investigator/_index.md
+++ b/content/newsletters/investigator/_index.md
@@ -11,7 +11,7 @@ layout = "news"
 sort-by = "month"
 occurence = "Every Thursday"
 image-gravity = "ce"
-
+weight = 2
 [cascade]
 image = "2021/06/01gc-4k5c-twja-965v.jpeg"
 +++

--- a/content/newsletters/palocal/_index.md
+++ b/content/newsletters/palocal/_index.md
@@ -8,7 +8,7 @@ modal-exclude = true
 layout = "news"
 sort-by = "month"
 occurence = "Every Friday"
-
+weight = 3
 [cascade]
 image = "2022/02/01gz-k3bg-4tet-0as8.png"
 +++

--- a/content/newsletters/papost/_index.md
+++ b/content/newsletters/papost/_index.md
@@ -10,7 +10,7 @@ modal-exclude = true
 layout = "news"
 sort-by = "month"
 occurence = "Each weekday"
-
+weight = 1
 [cascade]
 image = "2021/06/01gc-4k5b-cx91-fppc.jpeg"
 image-gravity = "ea"

--- a/content/newsletters/pennstatealert/_index.md
+++ b/content/newsletters/pennstatealert/_index.md
@@ -11,7 +11,7 @@ modal-exclude = true
 layout = "news"
 sort-by = "month"
 occurence = "When news breaks"
-
+weight = 6
 [cascade]
 image = "2023/02/01hx-t3ph-mmqa-hkt2.jpeg"
 nav = "statecollege"

--- a/content/newsletters/talkofthetown/_index.md
+++ b/content/newsletters/talkofthetown/_index.md
@@ -9,7 +9,7 @@ modal-exclude = true
 layout = "news"
 sort-by = "month"
 occurence = "Every Thursday"
-
+weight = 4
 [cascade]
 image = "2022/06/01hb-484c-z2hw-3tfc.jpeg"
 image-gravity = "ce"

--- a/layouts/_default/newsletters-signup.html
+++ b/layouts/_default/newsletters-signup.html
@@ -43,7 +43,7 @@
 
         {{ partial "tw/image-hero.html" . }}
       </header>
-      <div class="mx-auto max-w-screen-xl py-14 text-lg  font-medium lg:px-0">
+      <div class="mx-auto max-w-screen-xl py-14 text-lg font-medium lg:px-0">
         {{ with .Content }}
           <div class="article-content mx-auto mb-6 max-w-prose md:mb-12">
             {{ . }}


### PR DESCRIPTION
- Make the subheading “Get the best news from across PA straight to your inbox” a bit bigger
-  across PA straight to your inbox” a bit bigger? Reorder newsletters to: PA Post, Investigator, PA Local, Talk of the Town, Centre Documenters, Penn State Alerts
- Remove “County” from Centre Documenters
- Update Centre Documenters description