### PR TITLE
Fixes for Hugo v123

### DIFF
--- a/content/elections-2023.md
+++ b/content/elections-2023.md
@@ -14,7 +14,7 @@ blurb = "Spotlight PA wants to empower voters to make an informed decision on Ma
 url = "/elections-2023/"
 layout = "elections"
 type = "elections"
-guide = "content/series/voting-guides-2023/_index.md"
+guide = "series/voting-guides-2023/_index.md"
 credits = """
 {{<featured/credit
     eyebrow="Reporting"
@@ -133,7 +133,7 @@ title = "PA Election 2023: Candidate and Voting Guides"
 slug = "guides"
 layout = "story-collection"
 timeFilter = "2023-08-01"
-collection = "content/series/voting-guides-2023/_index.md"
+collection = "series/voting-guides-2023/_index.md"
 
 [[blocks]]
 layout = "ballyhoo"
@@ -185,7 +185,7 @@ title = "PA Election 2023: More Coverage "
 slug = "coverage"
 layout = "story-collection"
 timeFilter = "2023-08-01"
-collection = "content/topics/elections/_index.md"
+collection = "topics/elections/_index.md"
 collectionReadMore = "Read More PA Election 2023 Stories"
 
 [[blocks]]
@@ -193,7 +193,7 @@ title = " Elecciones Pa. 2023: Traducciones al Español "
 slug = "espanol"
 layout = "story-collection"
 timeFilter = "2023-08-01"
-collection = "content/topics/español/_index.md"
+collection = "topics/español/_index.md"
 collectionReadMore = "Leer Más Historias De La Elección PA 2023"
 
 [[internal-links]]

--- a/content/elections-2024.md
+++ b/content/elections-2024.md
@@ -18,7 +18,7 @@ aliases = [
 ]
 layout = "elections"
 type = "elections"
-guide = "content/series/voting-guides-2024/_index.md"
+guide = "series/voting-guides-2024/_index.md"
 credits = """
 {{<featured/credit
     eyebrow="Reporting"
@@ -136,7 +136,7 @@ title = "PA Election 2024: Voter Guides"
 slug = "guides"
 layout = "story-collection"
 timeFilter = "2023-12-01"
-collection = "content/series/voting-guides-2024/_index.md"
+collection = "series/voting-guides-2024/_index.md"
 
 [[blocks]]
 layout = "signup-inline"
@@ -149,7 +149,7 @@ title = "PA Election 2024: More Coverage"
 slug = "coverage"
 layout = "story-collection"
 timeFilter = "2023-12-01"
-collection = "content/topics/elections/_index.md"
+collection = "topics/elections/_index.md"
 collectionReadMore = "Read More PA Election 2024 Stories"
 
 [[internal-links]]

--- a/data/impact.json
+++ b/data/impact.json
@@ -6,7 +6,7 @@
       "date": "2022-10-28",
       "dek": "Spotlight PA broke the news that Penn State [hadn’t allocated funding to its Center for Racial Justice.",
       "kicker": "Penn State",
-      "page": "content/statecollege/2022-10-28-SPLPSUCENTER.md",
+      "page": "statecollege/2022-10-28-SPLPSUCENTER.md",
       "url": "https://spotlightpa.org/statecollege/2022/10/penn-state-psu-center-racial-justice-bendapudi/"
     },
     {
@@ -15,7 +15,7 @@
       "date": "2022-03-30",
       "dek": "A Spotlight PA investigation about the state’s broken compassionate relief program.",
       "kicker": "Justice System",
-      "page": "content/news/2022-03-30-SPLRELEASE30.md",
+      "page": "news/2022-03-30-SPLRELEASE30.md",
       "url": "https://spotlightpa.org/news/2022/03/pa-prison-life-sentence-compassionate-release/"
     },
     {
@@ -24,7 +24,7 @@
       "date": "2021-06-28",
       "dek": "State officials updated their policies after A Spotlight PA investigation found failure to clarify federal rules around funding for addiction treatment and medical marijuana use had deadly consequences.",
       "kicker": "Health",
-      "page": "content/news/2021-06-28-SPLMEDMAR28.md",
+      "page": "news/2021-06-28-SPLMEDMAR28.md",
       "url": "https://spotlightpa.org/news/2021/06/pa-medical-marijuana-insurance-drug-treatment-confusion/"
     },
     {
@@ -33,7 +33,7 @@
       "date": "2019-09-20",
       "dek": "After Spotlight PA revealed that the Pennsylvania State Police had quietly stopped tracking the race of drivers who get pulled over the State Police resumed tracking race data from traffic stops and resumed a data analysis partnership.",
       "kicker": "Justice System",
-      "page": "content/news/2019-09-20-SPLRACE20.md",
+      "page": "news/2019-09-20-SPLRACE20.md",
       "url": "https://spotlightpa.org/news/2019/09/pa-state-police-stopped-tracking-driver-race/"
     },
     {
@@ -42,7 +42,7 @@
       "date": "2021-04-29",
       "dek": "A Spotlight PA and Kaiser Health News investigation contributed to a new effort to give the state the authority to fine providers.",
       "kicker": "Health",
-      "page": "content/news/2021-04-29-SPLDDAP02.md",
+      "page": "news/2021-04-29-SPLDDAP02.md",
       "url": "https://spotlightpa.org/news/2021/04/pa-addiction-treatment-facilities-investigation-state-oversight-flawed-violations-harm-clients/"
     },
     {
@@ -51,7 +51,7 @@
       "date": "2020-08-06",
       "dek": "After Spotlight PA published an investigation in 2020 into how Pennsylvania’s higher education system failed students of color, public universities adopted a strategy to address campus racism.",
       "kicker": "Education",
-      "page": "content/news/2020-08-06-SPLCAMPUS06.md",
+      "page": "news/2020-08-06-SPLCAMPUS06.md",
       "url": "https://spotlightpa.org/news/2020/08/pennsylvania-public-universities-colleges-campus-racism/"
     },
     {
@@ -60,7 +60,7 @@
       "date": "2022-02-21",
       "dek": "A yearlong investigation into Pennsylvania’s medical marijuana card program.",
       "kicker": "Cannabis Card Game",
-      "page": "content/series/unproven-unsafe/_index.md",
+      "page": "series/unproven-unsafe/_index.md",
       "url": "https://spotlightpa.org/series/unproven-unsafe/"
     },
     {
@@ -69,7 +69,7 @@
       "date": "2020-05-09",
       "dek": "In spring 2020, Spotlight PA uncovered that the state had a plan to protect nursing homes from COVID-19 but didn’t fully implement it. In response, two state senators sent a letter demanding answers.",
       "kicker": "Coronavirus",
-      "page": "content/news/2020-05-09-SPLHOMES10.md",
+      "page": "news/2020-05-09-SPLHOMES10.md",
       "url": "https://spotlightpa.org/news/2020/05/pennsylvania-coronavirus-nursing-homes-plan-quick-strike-teams/"
     },
     {
@@ -78,7 +78,7 @@
       "date": "2021-05-01",
       "dek": "A Spotlight PA investigative series led to an unprecedented move towards transparency in Harrisburg",
       "kicker": "The Hidden Tab",
-      "page": "content/series/the-hidden-tab/_index.md",
+      "page": "series/the-hidden-tab/_index.md",
       "url": "https://spotlightpa.org/series/the-hidden-tab/"
     },
     {
@@ -87,7 +87,7 @@
       "date": "2022-11-18",
       "dek": "A Spotlight PA and NBC News investigation into the State Police shooting of Christian Hall in the Poconos revealedthat the teenager had his hands in the air when he was shot and killed.",
       "kicker": "Justice System",
-      "page": "content/news/2021-11-18-SPLHALL19.md",
+      "page": "news/2021-11-18-SPLHALL19.md",
       "url": "https://spotlightpa.org/news/2021/11/christian-hall-state-police-shooting-stroudsburg/"
     },
     {
@@ -96,7 +96,7 @@
       "date": "2023-01-09",
       "dek": "A Spotlight PA investigation into the state’s broken system for protecting incarcerated people with mental health needs.",
       "kicker": "Justice System",
-      "page": "content/news/2023-03-09-SPLCOMPETENCY.md",
+      "page": "news/2023-03-09-SPLCOMPETENCY.md",
       "url": "https://spotlightpa.org/news/2023/03/pa-mental-illness-jail-incompetent-treatment/"
     },
     {
@@ -105,7 +105,7 @@
       "date": "2021-01-29",
       "dek": "Spotlight PA found that the Department of Corrections was reporting flawed data about COVID-19 in prisons, prompting the department to remove, revamp, and relaunch a public data dashboard.",
       "kicker": "Coronavirus",
-      "page": "content/news/2021-01-29-SPLDATA30.md",
+      "page": "news/2021-01-29-SPLDATA30.md",
       "url": "https://spotlightpa.org/news/2021/01/pennsylvania-prisons-coronavirus-deaths-data-transparency/"
     },
     {
@@ -114,7 +114,7 @@
       "date": "2022-08-22",
       "dek": "A public records request prevailed in state appellate court, setting new precedential case law regarding the release of aggregate data.",
       "kicker": "Health",
-      "page": "content/news/2022-08-22-SPLCANORDER.md",
+      "page": "news/2022-08-22-SPLCANORDER.md",
       "url": "https://spotlightpa.org/news/2022/08/pa-medical-marijuana-program-addiction-treatment-court-order/"
     },
     {
@@ -123,7 +123,7 @@
       "date": "2020-08-30",
       "dek": "After Spotlight PA and The Appeal reported on illegal stops and searches by the Pennsylvania State Police, the governor requested a formal review.",
       "kicker": "Justice System",
-      "page": "content/news/2020-08-31-SPLFRISK31.md",
+      "page": "news/2020-08-31-SPLFRISK31.md",
       "url": "https://spotlightpa.org/news/2020/08/pa-state-police-troopers-highway-stop-and-frisk/"
     },
     {
@@ -132,7 +132,7 @@
       "date": "2023-01-23",
       "dek": "A Spotlight PA story prompted the state to fire the third-party contractor that was running the program.",
       "kicker": "Economy",
-      "page": "content/news/2023-01-23-SPLMORTGAGE.md",
+      "page": "news/2023-01-23-SPLMORTGAGE.md",
       "url": "https://spotlightpa.org/news/2023/01/pa-homeowner-mortgage-utility-assistance-fund/"
     },
     {
@@ -141,7 +141,7 @@
       "date": "2023-01-09",
       "dek": "A Spotlight PA investigation prompted state officials to admit the error and say it would return $19 million to Pennsylvanians.",
       "kicker": "Unemployment",
-      "page": "content/news/2021-07-09-SPLUNEMPLOYMENT10.md",
+      "page": "news/2021-07-09-SPLUNEMPLOYMENT10.md",
       "url": "https://spotlightpa.org/news/2021/07/pa-department-of-labor-unemployment-claims-overpayment-interest/"
     }
   ]

--- a/layouts/partials/blocks/series.html
+++ b/layouts/partials/blocks/series.html
@@ -21,7 +21,7 @@
               "text" "w-full md:w-2/6 md:text-right"
             }}
           {{ end }}
-          {{ with index site.Taxonomies.series (urlize .) }}
+          {{ with $seriesPage := site.GetPage (printf "series/%s" (urlize .)) }}
             <div class="{{ $classes.block }}">
               <div class="{{ $classes.image }}">
                 {{ $name := .Page.Param "image" }}
@@ -56,7 +56,7 @@
                   ><p
                     class="mt-4 text-base uppercase tracking-wider decoration-yellow decoration-4 underline-offset-4 group-hover:underline"
                   >
-                    {{- printf "%d Articles" (len .) -}}
+                    {{- printf "%d Articles" (.RegularPages.Len) -}}
                   </p></a
                 >
               </div>

--- a/layouts/partials/header/meta.html
+++ b/layouts/partials/header/meta.html
@@ -58,7 +58,7 @@
 {{- $permalink := .Permalink }}
 {{- $siteSeries := .Site.Taxonomies.series }}{{ with .Params.series }}
 {{- range $name := . }}
-  {{- $series := index $siteSeries (urlize $name) }}
+  {{- $series := site.GetPage (printf "series/%s" (urlize $name)) }}
   {{- range $page := first 6 $series.Pages }}
     {{- if ne $page.Permalink $permalink }}<meta property="og:see_also" content="{{ $page.Permalink }}" />{{ end }}
   {{- end }}

--- a/layouts/partials/helper/get-author.html
+++ b/layouts/partials/helper/get-author.html
@@ -2,8 +2,8 @@
 {{ $nameID := urlize . }}
 
 {{ $link := "" }}
-{{ with $pages := site.Taxonomies.authors.Get $nameID }}
-  {{ $link = $pages.Page.RelPermalink }}
+{{ with $page := site.GetPage (printf "authors/%s" $nameID) }}
+  {{ $link = $page.RelPermalink }}
 {{ end }}
 
 {{ $thumb := "" }}

--- a/layouts/partials/helper/get-impact-stories.html
+++ b/layouts/partials/helper/get-impact-stories.html
@@ -8,7 +8,7 @@
     "eyebrow" .kicker
     "url" .url
   }}
-  {{ with $page := site.GetPage (.page | default "-") }}
+  {{ with $page := site.GetPage (strings.TrimPrefix "content/" .page | default "-") }}
     {{ $params := partialCached "helper/page-params" $page.Page $page.RelPermalink }}
     {{ $item = $item | merge (dict
       "page" $page

--- a/layouts/partials/helper/get-items.html
+++ b/layouts/partials/helper/get-items.html
@@ -7,7 +7,7 @@
     "linkColor" .linkColor
     "backgroundColor" .backgroundColor
   }}
-  {{ with $page := site.GetPage (.page | default "-") }}
+  {{ with $page := site.GetPage (strings.TrimPrefix "content/" .page | default "-") }}
     {{ $params := partialCached "helper/page-params" $page.Page $page.RelPermalink }}
     {{ $item = $item | merge (dict
       "page" $page

--- a/layouts/partials/helper/get-stories.html
+++ b/layouts/partials/helper/get-stories.html
@@ -1,8 +1,10 @@
 {{ $stories := slice }}
 {{ $src := index site.Data .src }}
 {{ range index $src .name }}
-  {{ with site.GetPage . }}
+  {{ with site.GetPage (strings.TrimPrefix "content/" .) }}
     {{ $stories = $stories | append . }}
+  {{ else }}
+    {{ warnf "unknown story path %q" . }}
   {{ end }}
 {{ end }}
 

--- a/layouts/partials/helper/paginator.html
+++ b/layouts/partials/helper/paginator.html
@@ -4,7 +4,7 @@
 */}}
 
 {{ $p := "" }}
-{{ if .IsNode }}
+{{ if and .IsNode (ne .Kind "404") }}
   {{ $sort := .Param "sort-by" }}
   {{ $size := .Param "paginate" | default 30 }}
   {{ if eq $sort "pub" | or (eq $sort "oldest") }}

--- a/layouts/partials/tw/frontpage.html
+++ b/layouts/partials/tw/frontpage.html
@@ -191,7 +191,7 @@
       }}
     {{ end }}
     {{ if .featuredTopics }}
-      {{ $pages := site.GetPage "content/topics/the-capitol/_index.md" }}
+      {{ $pages := site.GetPage "topics/the-capitol/_index.md" }}
       {{ partial "tw/list-callout-story.html" (dict
         "hed" "The Capitol"
         "pages" $pages.RegularPages

--- a/layouts/partials/tw/homepage.html
+++ b/layouts/partials/tw/homepage.html
@@ -16,7 +16,7 @@
 {{ $editorPicksCallout := partial "helper/get-hp-picks" "edCallout" }}
 {{ $edInvestigations := partial "helper/get-hp-picks" "edInvestigations" }}
 {{ $edImpact := partial "helper/get-hp-picks" "edImpact" }}
-{{ $featuredTopics := "content/topics/the-capitol/_index.md" }}
+{{ $featuredTopics := "topics/the-capitol/_index.md" }}
 {{ $newsletter := site.GetPage "/newsletters/papost/_index.md" }}
 
 {{ $edNewsletter := "tw/list-callout-newsletter.html" }}

--- a/layouts/partials/tw/main-court-tool.html
+++ b/layouts/partials/tw/main-court-tool.html
@@ -2,7 +2,7 @@
   {{ .Content }}
 </article>
 
-{{ $elex := site.GetPage "content/series/pa-courts-101/_index.md" }}
+{{ $elex := site.GetPage "series/pa-courts-101/_index.md" }}
 
 {{ $pages := $elex.RegularPages }}
 {{ $primary := (time "2023-08-01").Unix }}
@@ -27,7 +27,7 @@
     }}
   </section>
 {{ end }}
-{{ $vet := site.GetPage "content/series/vetting-candidates/_index.md" }}
+{{ $vet := site.GetPage "series/vetting-candidates/_index.md" }}
 {{ $primary := (time "2023-08-01").Unix }}
 {{ $vetCand := where $vet.RegularPages
   ".PublishDate.Unix" "gt" $primary

--- a/layouts/partials/tw/main-transparency-tracker.html
+++ b/layouts/partials/tw/main-transparency-tracker.html
@@ -24,7 +24,7 @@
     id="transparency-tracker-stories"
     data-ga-category="guides"
   >
-    {{ $guide := site.GetPage "content/topics/transparency-tracker/_index.md" }}
+    {{ $guide := site.GetPage "topics/transparency-tracker/_index.md" }}
     {{ partial "tw/list-3-col-story.html" (dict
       "hed" "Transparency Stories"
       "pages" $guide.RegularPages
@@ -60,7 +60,7 @@
     id="penn-state-stories"
     data-ga-category="guides"
   >
-    {{ $guide := site.GetPage "content/topics/penn-state/_index.md" }}
+    {{ $guide := site.GetPage "topics/penn-state/_index.md" }}
     {{ partial "tw/list-3-col-story.html" (dict
       "hed" "All Penn State Stories"
       "pages" $guide.RegularPages

--- a/layouts/partials/tw/rail-events.html
+++ b/layouts/partials/tw/rail-events.html
@@ -1,4 +1,4 @@
-{{ $events := site.GetPage "content/topics/events/_index.md" }}
+{{ $events := site.GetPage "/topics/events/_index.md" }}
 {{ $pages := $events.RegularPages }}
 {{ $upcomingEvents := where $pages `Params.event-date` "gt" now }}
 {{ $upcomingEvents = sort $upcomingEvents `Params.event-date` "asc" }}

--- a/layouts/shortcodes/featured/related-stories.html
+++ b/layouts/shortcodes/featured/related-stories.html
@@ -14,7 +14,7 @@
 {{ $name := .Get "title" }}
 
 {{ with .Get "topic" }}
-  {{ $topic = (site.Taxonomies.topic.Get (urlize . )).Page }}
+  {{ $topic = site.GetPage (printf "topics/" (urlize . )) }}
   {{ $name = "Spotlight PA" }}
 {{ end }}
 {{ with .Get "title" }}

--- a/layouts/shortcodes/featured/series.html
+++ b/layouts/shortcodes/featured/series.html
@@ -10,7 +10,7 @@
 {{ $series := $params.series }}
 {{ $name := "This Series" }}
 {{ with .Get "series" }}
-  {{ $series = (site.Taxonomies.series.Get (urlize . )).Page }}
+  {{ $series = site.GetPage (printf "series/%s" (urlize .)) }}
   {{ $name = "Spotlight PA" }}
 {{ end }}
 {{ $pages := $series.Pages.ByPublishDate }}

--- a/layouts/shortcodes/featured/topic.html
+++ b/layouts/shortcodes/featured/topic.html
@@ -10,7 +10,7 @@
 {{ $topic := $params.topic }}
 {{ $name := $topic.Title }}
 {{ with .Get "topic" }}
-  {{ $topic = (site.Taxonomies.topic.Get (urlize . )).Page }}
+  {{ $topic = site.GetPage (printf "topics/" (urlize . )) }}
   {{ $name = "Spotlight PA" }}
 {{ end }}
 {{ with .Get "title" }}


### PR DESCRIPTION
This seems to be able to build on Hugo v118 and v123 without any changes to the deployed site. I still don't want us to upgrade now because I'm still seeing bugs in v0.123.7, like a paginated 404 page and duplicate items in the series list, but at least we will be ready if they ever work out the bugs.

See https://github.com/gohugoio/hugo/issues/12174 https://github.com/gohugoio/hugo/issues/12191 https://github.com/gohugoio/hugo/issues/12192