### PR TITLE
Newsletters: Use same action command everywhere

### DIFF
--- a/layouts/_default/elections-contest.html
+++ b/layouts/_default/elections-contest.html
@@ -1029,7 +1029,7 @@
           @focusin="active = true"
           x-form="newsletters:multi"
           data-ga-category="tout"
-          action="https://email-alerts.data.spotlightpa.org/api/subscribe"
+          action="{{ site.Param `newsletters-action` }}"
           method="post"
           target="_blank"
         >

--- a/layouts/_default/newsletters-signup.html
+++ b/layouts/_default/newsletters-signup.html
@@ -21,7 +21,7 @@
   {{ $titleClass := cond (gt (countwords .Title) 2) "is-size-1" "is-size-0" }}
   {{ $subheadClass := cond (gt (countwords $subtitle) 15) "is-size-4" "is-size-3" }}
   <form
-    action="{{ .Param `newsletters-action` }}"
+    action="{{ site.Param `newsletters-action` }}"
     method="post"
     target="_blank"
     data-ga-category="all-newsletters"

--- a/layouts/partials/embed/newsletter.html
+++ b/layouts/partials/embed/newsletter.html
@@ -1,7 +1,7 @@
 {{ $idEmail := partial "helper/new-id" . }}
 <form
   class="rounded border border-red font-sans font-semibold leading-tight shadow"
-  action="{{ .Param `newsletters-action` }}"
+  action="{{ site.Param `newsletters-action` }}"
   method="post"
   target="_blank"
   x-form="newsletters:multi"

--- a/layouts/partials/tw/inline-newsletter-box-sc.html
+++ b/layouts/partials/tw/inline-newsletter-box-sc.html
@@ -8,7 +8,7 @@
   x-data
   x-form="newsletters:talkofthetown"
   data-ga-category="tout"
-  action="{{ .Page.Param `newsletters-action` }}"
+  action="{{ site.Param `newsletters-action` }}"
   method="post"
   target="_blank"
 >

--- a/layouts/partials/tw/inline-newsletter-box.html
+++ b/layouts/partials/tw/inline-newsletter-box.html
@@ -9,7 +9,7 @@
   @focusin="active = true"
   x-form="newsletters:multi"
   data-ga-category="tout"
-  action="{{ .Page.Param `newsletters-action` }}"
+  action="{{ site.Param `newsletters-action` }}"
   method="post"
   target="_blank"
 >

--- a/layouts/partials/tw/inline-newsletter-white-sc.html
+++ b/layouts/partials/tw/inline-newsletter-white-sc.html
@@ -6,7 +6,7 @@
   @focusin="active = true"
   x-form="newsletters:talkofthetown"
   data-ga-category="tout"
-  action="{{ .Page.Param `newsletters-action` }}"
+  action="{{ site.Param `newsletters-action` }}"
   method="post"
   target="_blank"
 >

--- a/layouts/partials/tw/inline-newsletter-white.html
+++ b/layouts/partials/tw/inline-newsletter-white.html
@@ -6,7 +6,7 @@
   @focusin="active = true"
   x-form="newsletters:multi"
   data-ga-category="tout"
-  action="{{ .Page.Param `newsletters-action` }}"
+  action="{{ site.Param `newsletters-action` }}"
   method="post"
   target="_blank"
 >

--- a/layouts/partials/tw/modal-newsletter-sc.html
+++ b/layouts/partials/tw/modal-newsletter-sc.html
@@ -28,7 +28,7 @@
     <form
       class="m-auto w-full max-w-prose overflow-hidden rounded-lg text-center font-sans text-g-9 shadow-lg"
       x-form="newsletters:multi"
-      action="{{ .Param `newsletters-action` }}"
+      action="{{ site.Param `newsletters-action` }}"
       method="post"
       target="_blank"
       tabindex="-1"

--- a/layouts/partials/tw/modal-ribbon.html
+++ b/layouts/partials/tw/modal-ribbon.html
@@ -1,7 +1,6 @@
 {{ $idEmail := partial "helper/new-id" . | printf "modal-newsletter-%s" }}
 {{ $imagename := .filename }}
 {{ $actionColor := .actionColor | default "#FFCB05" }}
-{{ $newsletterAction := site.Param "newsletters-action" }}
 
 
 <div
@@ -63,7 +62,7 @@
           bg-white md:col-span-7 md:col-start-3 md:row-start-1 md:-ml-5 md:grid md:flex-col md:flex-wrap"
             x-form="newsletters:multi"
             x-data="{ hasFocused: false }"
-            action="{{ $newsletterAction }}"
+            action="{{ site.Param `newsletters-action` }}"
             method="post"
             target="_blank"
             tabindex="-1"

--- a/layouts/partials/tw/newsletter-box-lg.html
+++ b/layouts/partials/tw/newsletter-box-lg.html
@@ -1,5 +1,4 @@
 {{ $idEmail := partial "helper/new-id" . | printf "footer-newsletter-%s" }}
-{{ $newsletterAction := site.Param "newsletters-action" }}
 {{ $title := .newsletterHed }}
 {{ $dek := .newsletterDek | default "Get every Spotlight PA story and the best investigative journalism from across Pa." }}
 {{ $showLogo := .showLogo }}
@@ -40,7 +39,7 @@
     class=" mx-auto max-w-xl md:max-w-2xl"
     x-form="newsletters:multi"
     x-data="{ hasFocused: false }"
-    action="{{ $newsletterAction }}"
+    action="{{ site.Param `newsletters-action` }}"
     method="post"
     target="_blank"
   >

--- a/layouts/shortcodes/design/signups.html
+++ b/layouts/shortcodes/design/signups.html
@@ -105,7 +105,6 @@
   {{ $idEmail := partial "helper/new-id" . | printf "modal-newsletter-%s" }}
   {{ $imagename := "/2023/02/01hz-hk1z-0qfm-tsg4.jpeg" }}
   {{ $actionColor := "#FFCB05" }}
-  {{ $newsletterAction := site.Param "newsletters-action" }}
 
 
   <div class=" mx-[calc(-50vw_+_50%)]">
@@ -139,7 +138,7 @@
             class="col-span-5 col-start-1 row-start-1 -mr-5 grid-cols-[repeat(5,_auto)] gap-0 overflow-hidden rounded border-2
           bg-white md:col-span-7 md:col-start-3 md:row-start-1 md:-ml-5 md:grid md:flex-col md:flex-wrap"
             x-data="{ hasFocused: false }"
-            action="{{ $newsletterAction }}"
+            action="{{ site.Param `newsletters-action` }}"
             method="post"
             target="_blank"
             tabindex="-1"


### PR DESCRIPTION
I don't see how a stray quotation mark could have snuck into the URL here, but let's make them all consistent and see if that helps.