### PR TITLE
shortcodes/picture.html: Use absolute URL with imgProxy

### DIFF
--- a/layouts/partials/helper/build-srcset.html
+++ b/layouts/partials/helper/build-srcset.html
@@ -1,6 +1,7 @@
 {{ $sizes := .sizes }}
 {{ $imagename := .filename }}
 {{ $gravity := .gravity }}
+{{ $absURL := .absURL }}
 {{ $imgs := slice }}
 
 {{ range $sizes }}
@@ -13,6 +14,7 @@
     "height" $height
     "gravity" $gravity
     "ext" "webp"
+    "absURL" $absURL
   }}
   {{ $url := partial "helper/imgproxy" $imgOpt }}
   {{ $src := printf "%s %dw" $url $width }}

--- a/layouts/partials/helper/imgproxy.html
+++ b/layouts/partials/helper/imgproxy.html
@@ -1,4 +1,7 @@
 {{ $baseURL := getenv "IMGPROXY_URL" | default "https://images.data.spotlightpa.org" }}
+{{ if .absURL }}
+  {{ $baseURL = $baseURL | absURL }}
+{{ end }}
 {{ $signature := "insecure" }}
 {{ $resizing_type := .resize | default "fill" }}
 {{ $width := .width }}
@@ -23,4 +26,8 @@
   $extension
 }}
 
-{{ return ($url | relURL) }}
+{{ if not .absURL }}
+  {{ $url = $url | relURL }}
+{{ end }}
+
+{{ return $url }}

--- a/layouts/partials/tw/image-block.html
+++ b/layouts/partials/tw/image-block.html
@@ -6,6 +6,7 @@
 {{ $credit := .credit }}
 {{ $eager := .eager | default false }}
 {{ $gravity := .gravity }}
+{{ $absURL := .absURL }}
 {{ $rounded := cond (.rounded|not|not) "rounded" "" }}
 {{ $shadow := cond (.shadow|not|not) "shadow" "" }}
 {{ $creditClass := .creditClass | default "mt-1 w-full px-1 text-right font-sans text-xs uppercase leading-tight text-credit" }}
@@ -23,6 +24,7 @@
   "sizes" $sizes
   "filename" $imagename
   "gravity" $gravity
+  "absURL" $absURL
   )
 }}
 
@@ -33,6 +35,7 @@
   "width" $width
   "height" $height
   "gravity" $gravity
+  "absURL" $absURL
 }}
 {{ $imgSmallSrc := partial "helper/imgproxy" $imgOpt }}
 

--- a/layouts/shortcodes/picture.html
+++ b/layouts/shortcodes/picture.html
@@ -18,6 +18,7 @@
     "sizeHint" "670px"
     "rounded" true
     "gravity" $gravity
+    "absURL" true
   }}
   {{ partial "tw/image-block.html" $imgOpts }}
 </div>


### PR DESCRIPTION
The mobile app doesn't seem to be able to interpret relative URLs here, so just make them absolute by passing a new "absURL" parameter up the stack. We could just make everything absolute, but that would bloat the HTML size a little.