### PR TITLE
shortcodes/picture.html: Drop minimum image size

### DIFF
--- a/layouts/partials/tw/image-hero.html
+++ b/layouts/partials/tw/image-hero.html
@@ -17,7 +17,7 @@
     "widthRatio" 3
     "heightRatio" 2
     "sizeHint" "(min-width: 850px) 669px, 90vw"
-    "widths" (slice 300 480 669 1024 1338)
+    "widths" (slice 669 1024 1338)
     "rounded" true
     "figClass" "mt-6" | merge $imgOpts
   }}
@@ -27,7 +27,7 @@
     "widthRatio" 16
     "heightRatio" 9
     "sizeHint" "(min-width: 1080px) 850px, (min-width: 850px) 669px, 90vw"
-    "widths" (slice 300 480 669 1024 1338)
+    "widths" (slice 669 1024 1338)
     "rounded" true
     "figClass" "mt-6" | merge $imgOpts
   }}

--- a/layouts/shortcodes/picture.html
+++ b/layouts/shortcodes/picture.html
@@ -14,8 +14,8 @@
     "caption" $caption
     "widthRatio" $widthRatio
     "heightRatio" $heightRatio
-    "widths" (slice 670 1340)
-    "sizeHint" "670px"
+    "widths" (slice 669 1338)
+    "sizeHint" "669px"
     "rounded" true
     "gravity" $gravity
     "absURL" true

--- a/layouts/shortcodes/picture.html
+++ b/layouts/shortcodes/picture.html
@@ -14,7 +14,7 @@
     "caption" $caption
     "widthRatio" $widthRatio
     "heightRatio" $heightRatio
-    "widths" (slice 320 670 1340)
+    "widths" (slice 670 1340)
     "sizeHint" "670px"
     "rounded" true
     "gravity" $gravity


### PR DESCRIPTION
You can't buy a phone with less than 670 device pixels across, and the app is sucking in the minimum size here for some reason.