### PR TITLE
embeds/tips: Fix tip text not rending bold/italic tags

### DIFF
--- a/layouts/shortcodes/embed/tips.html
+++ b/layouts/shortcodes/embed/tips.html
@@ -2,7 +2,7 @@
 {{ $idEmail := partial "helper/new-id" . }}
 {{ $idTip := partial "helper/new-id" . }}
 
-{{ $tip := .Get "tip_text" | htmlUnescape | default `` }}
+{{ $tip := .Get "tip_text" | htmlUnescape | safeHTML | default `` }}
 {{ $eyebrow := .Get "flag_text" | htmlUnescape | default `Tips` }}
 {{ $formName := .Get "form_name" | htmlUnescape | default `contact-page` }}
 


### PR DESCRIPTION
See https://spotlightpa.org/news/2024/12/pennsylvania-medical-marijuana-top-doctor-certification/ for an example of the problem.