### PR TITLE
tw/nav.html: Fix donate pop up on modal-excluded pages

### DIFF
--- a/layouts/partials/tw/nav.html
+++ b/layouts/partials/tw/nav.html
@@ -183,9 +183,11 @@
         data-fru-campaign="navbar"
         data-ga-category="donate"
         class="group flex items-center justify-around overflow-hidden rounded-md bg-gradient-to-r from-red-7 to-red p-2 text-white hover:from-red-5 hover:to-red-9 sm:justify-center md:-my-1 md:p-2 lg:px-4"
-        x-data
         href="/donate/"
-        :href="'#form=donate-onetime?utm_source=www.spotlightpa.org&utm_medium=home&utm_campaign=navbar'"
+        {{ if not (page.Param "modal-exclude") }}
+          x-data
+          :href="'#form=donate-onetime?utm_source=www.spotlightpa.org&utm_medium=home&utm_campaign=navbar'"
+        {{ end }}
       >
         <span
           class="flex-0 relative inline-flex flex-wrap items-center text-xs font-bold uppercase leading-none tracking-wide md:text-sm md:leading-none"


### PR DESCRIPTION
If a page is 'modal-exclude', it won't have the Fundraise Up code, so the donate popup won't load.