### PR TITLE
Homepage: Drop stale PA Post promo and promote PA Local

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -11,11 +11,11 @@ newsletter-hed = "Sign up for our newsletters"
 newsletter-dek = "Get the top stories and best investigative journalism from across Pa. with our free newsletters."
 
 
-callout-hed = "Latest From Our Daily Newsletter"
-signup-hed = "Start your morning with PA Post"
-signup-dek = "We help you understand what's happening across Pennsylvania - in less than five minutes a day."
+callout-hed = "Good News from Pennsylvania"
+signup-hed = "A weekly dose of positive news"
+signup-dek = "A fresh look at the incredible people, beautiful places, and delicious food Pennsylvania has to offer."
 signup-cta = "Sign up"
-signup-image = "2021/06/01gc-4k5b-cx91-fppc.jpeg"
-signup-field = "newsletter/papost-hidden.html"
+signup-image = "2022/02/01h0-cwm9-x8wv-b6tc.jpeg"
+signup-field = "newsletter/palocal-hidden.html"
 
 +++

--- a/layouts/partials/tw/frontpage.html
+++ b/layouts/partials/tw/frontpage.html
@@ -227,10 +227,9 @@
         )
       }}
     {{ end }}
-    {{ if .edNewsletter }}
-      {{ $pages := .newsletter }}
+    {{ if .showNewsletterCallout }}
+      {{ $pages := .newsletterCalloutRiver }}
       {{ partial "tw/list-callout-newsletter.html" (dict
-
         "calloutHed" (page.Param "callout-hed")
         "signupHed" (page.Param "signup-hed")
         "signupDek" (page.Param "signup-dek")

--- a/layouts/partials/tw/homepage.html
+++ b/layouts/partials/tw/homepage.html
@@ -18,9 +18,6 @@
 {{ $edImpact := partial "helper/get-hp-picks" "edImpact" }}
 {{ $featuredTopics := "topics/the-capitol/_index.md" }}
 
-{{ $showNewsletterCallout := true }}
-{{ $newsletterCalloutRiver := site.GetPage "topics/PA Local/_index.md" }}
-
 {{ $bureau := site.GetPage "/statecollege/" }}
 {{ $paPost := site.GetPage "/newsletters/papost" }}
 {{ $river := sort $news.RegularPages ".PublishDate" "desc" }}
@@ -44,8 +41,8 @@
   "edInvestigations" $edInvestigations
   "edImpact" $edImpact
 
-  "showNewsletterCallout" $showNewsletterCallout
-  "newsletterCalloutRiver" $newsletterCalloutRiver
+  "showNewsletterCallout" true
+  "newsletterCalloutRiver" (site.GetPage "topics/PA Local/_index.md")
   "newsletterHed" "Latest From Our Daily Newsletter"
   "bureau" $bureau
   "river" $river

--- a/layouts/partials/tw/homepage.html
+++ b/layouts/partials/tw/homepage.html
@@ -17,9 +17,9 @@
 {{ $edInvestigations := partial "helper/get-hp-picks" "edInvestigations" }}
 {{ $edImpact := partial "helper/get-hp-picks" "edImpact" }}
 {{ $featuredTopics := "topics/the-capitol/_index.md" }}
-{{ $newsletter := site.GetPage "/newsletters/papost/_index.md" }}
 
-{{ $edNewsletter := "tw/list-callout-newsletter.html" }}
+{{ $showNewsletterCallout := true }}
+{{ $newsletterCalloutRiver := site.GetPage "topics/PA Local/_index.md" }}
 
 {{ $bureau := site.GetPage "/statecollege/" }}
 {{ $paPost := site.GetPage "/newsletters/papost" }}
@@ -44,8 +44,8 @@
   "edInvestigations" $edInvestigations
   "edImpact" $edImpact
 
-  "edNewsletter" $edNewsletter
-  "newsletter" $newsletter
+  "showNewsletterCallout" $showNewsletterCallout
+  "newsletterCalloutRiver" $newsletterCalloutRiver
   "newsletterHed" "Latest From Our Daily Newsletter"
   "bureau" $bureau
   "river" $river

--- a/layouts/statecollege/list.html
+++ b/layouts/statecollege/list.html
@@ -32,9 +32,6 @@
 
   {{ $pinnedStories := partial "helper/get-sc-picks" "topSlots" }}
 
-  {{ $newsletter := site.GetPage "/newsletters/talkofthetown/_index.md" }}
-  {{ $edNewsletter := "tw/list-callout-newsletter-sc.html" }}
-  {{ $paPost := site.GetPage "/newsletters/talkofthetown" }}
   {{ $river := sort $sc.RegularPages ".PublishDate" "desc" }}
 
   {{ $river = $river | complement $featuredStory $pinnedStories $topperStory }}
@@ -72,9 +69,6 @@
     {{ partial "tw/frontpage" (dict
       "featuredStories" $featuredStories
       "pinnedStories" $pinnedStories
-      "edNewsletter" $edNewsletter
-      "newsletter" $newsletter
-      "newsletterHed" "Latest Talk of the Town"
       "river" $river
       "riverTitle" $riverTitle
       "marginClass" $marginClass


### PR DESCRIPTION
Also drop the stale Talk of the Town box from State College's frontpage and rename variables to be clearer.