### PR TITLE
Add Opioid Settlement quiz

### DIFF
--- a/content/interactives/opioid-quiz.md
+++ b/content/interactives/opioid-quiz.md
@@ -1,0 +1,190 @@
++++
+blurb = "Use our interactive tool to decide how opioid settlement funds should be spent in Pennsylvania — and compare your results to a secretive oversight board."
+description = "Use this interactive tool to share your views on what types of spending should be approved for Pennsylvania’s opioid settlement funds."
+extended-kicker = "News Quiz"
+feed-exclude = false
+image = "2025/03/01kx-72ws-8643-y2p4.jpeg"
+image-credit = "Daniel Fishel for Spotlight PA"
+image-description = ""
+internal-id = "OPIOIDQUIZ"
+kicker = ""
+layout = "blocks"
+modal-exclude = true
+no-index = true
+pinned = false
+suppress-date = false
+title = "You can decide how billions to fight the opioid epidemic should be spent with this new tool"
+title-tag = "Pa. opioid settlement money: How should it be spent?"
+url = "/news/2025/03/pennsylvania-opioid-settlement-decide-spending/"
+
+[[blocks]]
+  layout = "content"
+  content = """Hundreds of millions of dollars from opioid settlements have flowed into Pennsylvania to help the state respond to an epidemic that kills thousands of people each year — and even more money is expected in the years to come. But a powerful state oversight board has routinely blocked members of the public from having a meaningful say in how the money should be used.
+
+  Members of the Pennsylvania Opioid Misuse and Addiction Abatement Trust regularly [meet in secret](https://www.spotlightpa.org/news/2024/06/pennsylvania-opioid-settlement-board-secret-meetings-lawmaker-challenge/) and have not allowed [public comment](https://www.spotlightpa.org/news/2024/08/opioid-settlement-cash-public-comments-ignored/) at their open meetings. The trust can withhold future funds if board members decide counties or other local governments spent money inappropriately — but there have been big disagreements and even some court cases over what counts [as inappropriate spending](https://www.spotlightpa.org/news/2024/11/pennsylvania-opioid-settlement-money-commonwealth-court-spending-lawsuits/).
+
+  There’s a lot at stake, as the state could receive [billions of dollars over many years](https://www.spotlightpa.org/news/2023/05/pa-opioid-settlement-money-explained/). Most of the money ultimately goes to the state’s 67 counties, and their approaches to transparency and public input vary. The spending decisions they and the state’s oversight board make have far-reaching consequences, and those choices have already prompted conflicts over law enforcement spending, programs related to children and families, and money for residents of a Philadelphia neighborhood.
+
+  To help people better understand the debates over these choices and their impact, Spotlight PA has created this interactive tool. Step into the role of a decision-maker and see how settlement outcomes might change if you were in charge.
+  """
+
+[[blocks]]
+  layout = "typeform-button"
+  typeformid = "01JP6QA39V0FTX8RRGQ46G4G8E"
+
+[[blocks]]
+  layout = "content"
+  content = """
+[Spotlight PA reporter Ed Mahon](https://www.spotlightpa.org/authors/ed-mahon/) wrote these questions based on information from the state’s opioid trust, materials obtained through Pennsylvania’s [open records law](https://www.spotlightpa.org/news/2024/03/opioid-settlement-money-67-counties/), court documents, interviews, published articles, and other research. He also drew from a Spotlight PA [spending database](https://www.spotlightpa.org/news/2024/11/pennsylvania-opioid-settlement-money-spending-data/) that covers the 2022 and 2023 reporting period. Mahon reported this story while participating in the [USC Annenberg Center for Health Journalism’s](https://centerforhealthjournalism.org/about-center) 2024 Data Fellowship and received engagement mentoring and funding to explore the potential uses of the funds for children and families impacted by the opioid crisis. You can send your feedback to him at [emahon@spotlightpa.org](mailto:emahon@spotlightpa.org).
+  """
+
+[[blocks]]
+  layout = "show-results-start"
+  id = "results"
+
+[[blocks]]
+  layout = "content"
+  content = """
+### Results are next, but first...
+
+{{<embed/newsletter
+  cta="Sign up for Spotlight PA's free daily newsletter and discover overlooked stories, unique investigations, and daily joy from across PA."
+  preselect="papost"
+>}}
+
+[Learn more](#answer-key) about each of these topics from the interactive tool, [answer the questions again][again], or contribute to our reporting by sharing your  [thoughts and experiences](https://www.spotlightpa.org/news/2025/02/pennsylvania-opioid-settlement-tracking-public-input/) regarding the opioid crisis.
+
+[again]: javascript:document.querySelector('button[data-tf-popup]').click()
+
+## How Your Choices Compare
+  """
+
+[[blocks]]
+  layout = "opioid-quiz-results"
+  typeformid = "01JP6QA39V0FTX8RRGQ46G4G8E"
+
+[[blocks]]
+  layout = "opioid-quiz-key"
+  id = "answer-key"
+[[blocks.answers]]
+  hed = "Child care for parents with opioid use disorder"
+  body = """The trust last year approved [about $906,000](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A5:L5) for an Allegheny County program that supports parents and guardians "who need child care support while undergoing treatment or job seeking and do not qualify for state funded child care subsidies."
+
+  A national coalition of harm reduction, recovery, and other groups described this program as a [good use of settlement funds](https://static1.squarespace.com/static/640e4d9374e80160b84e0be4/t/66c356f3c1507d1a79044f69/1724077811524/A+Roadmap+for+Opioid+Settlement+Funds_+Supporting+Communities+%26+Ending+the+Overdose+.pdf). [Testimony](https://www.rural.pa.gov/download.cfm?file=Resources/PDFs/news/CHOP%20Testimony.pdf) from officials at PolicyLab at Children's Hospital of Philadelphia also highlighted this program and suggested other counties could consider a similar approach "to invest in child care system gaps."
+  """
+[[blocks.answers]]
+  hed = "Salary increases for child welfare workers in Cameron County"
+  body = """Funds were dedicated to increasing salaries in child welfare and probation offices that have historically not been "compensated fairly or equitably for the additional requirements the opioid epidemic has caused," [the county said](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A104:L104) in a spending report. The trust board [rejected the choice](https://www.spotlightpa.org/news/2025/02/pennsylvania-child-welfare-crisis-opioid-settlement-funding/). But after an appeal from Cameron County, the trust's Dispute Resolution Committee in January decided to send the issue back to the full board.
+
+  At the board's public meeting in February, trust officials approved the [funds for the child welfare](https://bsky.app/profile/edmahon.bsky.social/post/3lhygpdu7vc2u) portion, which totaled about $9,000, but they did not reach a final decision on the county's probation workers."""
+[[blocks.answers]]
+  hed = "Outdoor activities and youth mentorship in Somerset County"
+  body = """The trust rejected $30,000 for this program. The program is available to children in ninth through 12th grades from the county's largest school district, and it provides mentors and weekly opportunities for outdoor activities, according to [testimony as summarized in the county's appeal](https://www.documentcloud.org/documents/25545436-244-md-2024-memo-of-law-filed-1/).
+
+  Tom VanKirk, chair of the trust, told county officials that trust members were assessing whether settlement money goes directly to help prevent opioid abuse and not just whether something is "a nice project."
+
+  The county appealed to [Commonwealth Court](https://www.documentcloud.org/documents/25505658-somerset-county/) in October, arguing that the initiative was compliant as an evidence-informed program. [In response](https://www.documentcloud.org/documents/25505360-244-md-2022-answer-to-app-for-relief-nov/), attorneys for the trust maintained that the county's program is not compliant.
+"""
+[[blocks.answers]]
+  hed = "Improvements to schools and parks in Philadelphia's Kensington neighborhood"
+  body = """The trust originally [rejected these ](https://www.spotlightpa.org/news/2024/06/pennsylvania-opioid-cash-trust-decisions/)efforts in June. One member said that "the trust is not a community development program," while another said they needed "to do the letter of the law when it comes to [Exhibit E](https://www.attorneygeneral.gov/wp-content/uploads/2021/12/Exhibit-E-Final-Distributor-Settlement-Agreement-8-11-21.pdf)." That's a settlement document that describes approved uses for the money, but also says strategies "may include, but are not limited to," those listed.
+
+  Philadelphia [appealed](https://www.documentcloud.org/documents/25365044-20240812-philadelphia-complaint-submitted-aug-9-7/), arguing that trust officials "ignored the empirical relationship between trauma and substance use"  and that interventions targeting the most at-risk communities "are effective at preventing opioid misuse and abuse."  A  committee of the trust [reversed the rejections for these initiatives](https://www.kensingtonvoice.com/en/opioid-trust-ruling-favors-kensington-schools-parks-and-rent-and-mortgage-relief-but-not-home-repairs-or-small-businesses/). At the same meeting, the committee also decided the city's use of the funds for [rent and mortgage assistance](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A389:L389) was compliant.
+"""
+[[blocks.answers]]
+  hed = "Repairs for homes and support for small businesses in Philadelphia's Kensington neighborhood"
+  body = """The trust originally [rejected these ](https://www.spotlightpa.org/news/2024/06/pennsylvania-opioid-cash-trust-decisions/)efforts in June. One member said that "the trust is not a community development program," while another said they needed "to do the letter of the law when it comes to [Exhibit E](https://www.attorneygeneral.gov/wp-content/uploads/2021/12/Exhibit-E-Final-Distributor-Settlement-Agreement-8-11-21.pdf)." That's a settlement document that describes approved uses for the money, but also says strategies "may include, but are not limited to," those listed. A committee of the trust  [upheld the rejections for these ](https://www.kensingtonvoice.com/en/opioid-trust-ruling-favors-kensington-schools-parks-and-rent-and-mortgage-relief-but-not-home-repairs-or-small-businesses/)initiatives.
+
+  The [city later](https://www.spotlightpa.org/news/2024/11/pennsylvania-opioid-settlement-money-commonwealth-court-spending-lawsuits/)  appealed to Commonwealth Court, arguing Philadelphia is using interventions that "target root causes of addiction and are supported by empirical studies and the latest recommendations from national leaders." [Philadelphia's appeal](https://www.documentcloud.org/documents/25365056-20241104-memo-of-law-stamped/?responsive=1&title=1) describes $3.4 million it says was wrongly denied, although figures previously released by the trust describe a lower amount.
+
+  Attorneys for the [trust argued](https://www.documentcloud.org/documents/25497250-244-md-2022-memorandum-of-law-dec/#document/p6) that the city "failed to establish that providing handouts to residents and small business owners in Kensington would remediate or prevent" opioid use disorder or "mitigate the effects of the opioid epidemic."
+"""
+[[blocks.answers]]
+  hed = "Advertising and media campaigns in multiple counties"
+  body = """Settlement documents list funding media campaigns to prevent opioid use and misuse, as well as other public education efforts, as approved uses for the money.
+
+  Searching for "advertising" in [Spotlight PA's spending database](https://www.spotlightpa.org/news/2024/11/pennsylvania-opioid-settlement-money-spending-data/) shows eight results, including [$200,000 for a Carbon County](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A106:L106) program. The database also shows similar programs elsewhere: $150,000 for media campaigns in [Bucks County](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A87:L87), about $263,000 for a fentanyl awareness campaign in [Monroe County](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A296:L296), and $300,000 for a public education campaign in [Allegheny County](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A17:L17).
+
+  Trust officials and Northampton County have sparred over a newsletter portion of a media campaign. The trust decided only about $4,200 out of about $22,000 spent on the newsletter effort was compliant, according to [an appeal from the county](https://www.documentcloud.org/documents/25505368-northampton-county-appeal/).
+
+  The county argued that all of the money should be allowed and that the "newsletter combined prominent placement of the 'Fake is Real' advertising with information about county resources." [In its response](https://www.documentcloud.org/documents/25510483-244-md-2022-answer-to-app-for-relief-dec/), attorneys for the trust said the "vast majority of the content in the County Newsletter has nothing to do with" opioid use disorder "remediation or prevention."
+"""
+[[blocks.answers]]
+  hed = "Body scanner at the Clearfield County jail"
+  body = """The trust approved $65,000 for this program, which the county said aimed to prevent the smuggling and distribution of illicit drugs. "Prior to installing this system we had an inmate smuggle opioids into the facility, resulting in 3 overdoses," the [county's report said.](https://www.documentcloud.org/documents/24489442-clearfield-county-opioid-settlement-report/#document/p3) "One of the three resulted in the death of an inmate."
+
+  A national coalition of harm reduction, recovery, and other groups criticized a Michigan county for a similar use of settlement funds, calling a body scanner for a jail an example of [problematic spending](https://static1.squarespace.com/static/640e4d9374e80160b84e0be4/t/66c356f3c1507d1a79044f69/1724077811524/A+Roadmap+for+Opioid+Settlement+Funds_+Supporting+Communities+%26+Ending+the+Overdose+.pdf).
+"""
+[[blocks.answers]]
+  hed = "Detective in Cameron County"
+  body = """The trust rejected funds [for this initiative](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A103:L103). A county description referred to the creation of a "point person to build a coalition encompassing enforcement, treatment, and education." The trust has [released public guidance](https://www.paopioidtrust.org/about-us/faqs) saying "any type of policing activity would not be considered allowable spending." (The county's original report and trust records listed $20,000 for this program, [although additional county records](https://www.documentcloud.org/documents/25506941-second-follow-up-june-request-submission/) obtained through the state's Right-to-Know Law listed a lower amount.)
+
+  Opioid addiction medication for people in county jails
+
+  [Exhibit E](https://www.attorneygeneral.gov/wp-content/uploads/2021/12/Exhibit-E-Final-Distributor-Settlement-Agreement-8-11-21.pdf), a settlement document that describes allowable spending, specifically lists increasing funding for jails to provide treatment to inmates with opioid use disorder as a priority for the funds.
+
+  Millions of dollars in settlement money have gone to medication, counseling, or other treatment-related purposes in Pennsylvania jails. Searching for "prison" or "jail" in Spotlight PA's [spending database](https://www.spotlightpa.org/news/2024/11/pennsylvania-opioid-settlement-money-spending-data/) shows more than 30 results, including in [Allegheny](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A13:L13), [Berks](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A29:L29), [Bucks](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A91:L91), [Butler](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A98:L98), [Chester](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A129:L129), [Clearfield](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A150:L150), [Cumberland](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A155:L155), [Elk](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A199:L199),[ Erie](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A205:L205), [Lancaster](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A249:L249), [Lehigh](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A266:L266), [McKean](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A274:L274), [Mrcer](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A279:L279), [Perry](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A315:L315), and [Westmoreland](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A443:L443) Counties. The level of detail available on each program through trust records varies widely.
+
+  The trust approved each of those programs. [A report](https://www.documentcloud.org/documents/25550109-2024-moud-report-update-print/#document/p1) from the [Pennsylvania Institutional Law Project](https://pilp.org/moud) said the expansion of opioid use disorder medication in jails is "an important and much-needed shift" but noted "much more work remains to be done." A [national coalition](https://static1.squarespace.com/static/640e4d9374e80160b84e0be4/t/66c356f3c1507d1a79044f69/1724077811524/A+Roadmap+for+Opioid+Settlement+Funds_+Supporting+Communities+%26+Ending+the+Overdose+.pdf) of harm reduction, recovery, and other groups supports using settlement funds to increase access to opioid use disorder medications in prisons and jails, but not as a replacement for existing money for these efforts.
+"""
+[[blocks.answers]]
+  hed = "Allegheny County program that provides access to sterile syringes and other supplies to support safer drug use"
+  body = """The trust in May approved the county's decision to dedicate [$325,000 for a syringe services program](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A14:L14), despite public opposition from one board member. These programs have widespread support in the medical community, but are widely considered [illegal in most of the state](https://kffhealthnews.org/news/article/clean-needles-syringe-services-programs-legal-gray-area-risk-pennsylvania/). [Philadelphia](https://www.phila.gov/media/20210602143030/executive-order-1992-04.pdf) and [Allegheny County](https://alleghenycounty.legistar.com/LegislationDetail.aspx?ID=1700380&GUID=4EAEF006-D2C2-4A07-A919-798D5E49E638&Options=ID%7CText%7C&Search=needle+exchange) officials took action years ago to allow them.
+"""
+[[blocks.answers]]
+  hed = "Coroner offices in multiple counties"
+  body = """The trust last year approved at least four coroner-related programs: $24,000 in [Mercer County](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A277:L277), $25,000 in [Lawrence County](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A261:L261), $30,600 in [Lehigh County](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A268:L268), and $140,000 in [Chester County](https://docs.google.com/spreadsheets/d/1o6PovO8zFXaD4mn9VhUK9hoKmECRMU4uzu2IBIRmemo/edit?gid=0#gid=0&range=A126:L126). Some advocates for people dealing with addiction said they were concerned the money would support prosecutions of people accused of providing drugs, or they thought the use drifted too far from the goal of [keeping people alive](https://www.spotlightpa.org/news/2024/05/opioid-settlement-money-coroner-controversy/). A trust member told Spotlight PA the funding could help relieve some of the stress the opioid crisis has put on coroners, and county officials described multiple benefits for the programs. A Chester County official told Spotlight PA it "has never been the intent to prosecute the individual suffering from substance use disorder."
+"""
+[[blocks.answers]]
+  hed = "Assistant public defender in Elk County"
+  body = """The trust offered guidance discouraging [this type of spending](https://www.spotlightpa.org/news/2024/04/opioid-settlement-cash-boon-to-pennsylvania-prosecutors-but-public-defenders-are-being-turned-away/), even though opioid settlement money flows to some district attorneys' offices in the state. The [trust's explanation](https://www.paopioidtrust.org/about-us/faqs) said "the services of an assistant public defender are required to be provided by the counties." A [national coalition](https://static1.squarespace.com/static/640e4d9374e80160b84e0be4/t/66c356f3c1507d1a79044f69/1724077811524/A+Roadmap+for+Opioid+Settlement+Funds_+Supporting+Communities+%26+Ending+the+Overdose+.pdf) of harm reduction, recovery, and other groups criticized the disparity between prosecutors and public defenders. In a lawsuit, the [ACLU of Pennsylvania](https://www.aclupa.org/sites/default/files/field_documents/warren_v_commonwealth_petition_for_review_-_final.pdf) did as well.
+
+  The trust later approved funding for a social worker position within a public defender's office.
+"""
+[[blocks.answers]]
+  hed = "Public comment at regular meetings of the trust where these spending decisions are made"
+  body = """A trust official previously told Spotlight PA and KFF Health News that state law doesn't require the trust to offer public comment at its meetings and the public is encouraged to participate at the local level.
+
+  Pennsylvania's board is one of at least 14 similar opioid councils that routinely block the public from speaking at their meetings, [a first-of-its-kind survey](https://www.spotlightpa.org/news/2024/08/opioid-settlement-cash-public-comments-ignored/) from Spotlight PA and KFF Health News found last year. A former member of Maine's opioid council cited the findings as she urged her council to allow [comment at all regular meetings](https://www.youtube.com/watch?v=HPH6YOewdFM&t=7505s). And in a change, Pennsylvania's opioid settlement board in February agreed to [host a public listening session later in the year](https://bsky.app/profile/edmahon.bsky.social/post/3li3l336as223).
+"""
+
+[[blocks]]
+layout = "content"
+content = """
+### How you would spend the money
+
+We're interested in hearing more from you on this topic. You can contact reporter Ed Mahon at [emahon@spotlightpa.org](mailto:emahon@spotlightpa.org) or submit your comments through [this form](https://docs.google.com/forms/d/e/1FAIpQLSdZnu3M8z7JUlEAlz8l47UWesZ30JqjqvUvIQr4RFE0yNah6g/viewform?usp=header).
+"""
+
+[[blocks]]
+  layout = "show-results-end"
+
+[[blocks]]
+  layout = "credits"
+  credits = """{{<featured/credit
+    eyebrow="Reporting"
+    name="Ed Mahon"
+    role="Investigative Reporter"
+    email="emahon@spotlightpa.org"
+>}}
+{{<featured/credit
+    eyebrow="Editing"
+    name="Matt Dempsey"
+    role="Senior Editor for Investigations"
+    email="mdempsey@spotlightpa.org"
+>}}
+{{<featured/credit
+    eyebrow="Illustration"
+    name="Daniel Fishel"
+    role="For Spotlight PA"
+>}}
+{{<featured/credit
+    eyebrow="Layout"
+    name="Carlana Johnson"
+    role="Director of Technology"
+    email="cjohnson@spotlightpa.org"
+>}}"""
+
+[[blocks]]
+  layout = "donate-slim"
++++

--- a/layouts/_default/blocks.html
+++ b/layouts/_default/blocks.html
@@ -1,0 +1,68 @@
+{{ define "html-class" -}}
+  scroll-smooth
+{{- end }}
+
+{{ define "body-class" -}}
+  font-sans
+{{- end }}
+
+{{ define "main" }}
+  {{ if not (.Param "hide-title") }}
+    <header class="bg-white px-5 pb-4 pt-8 text-black">
+      <div class="mx-auto max-w-screen-lg">
+        {{ partial "tw/breadcrumbs.html" . }}
+      </div>
+      <div class="mx-auto w-full max-w-2xl">
+        <h1
+          class="font-sans text-3xl font-bold leading-none text-black sm:text-4xl lg:text-5xl"
+        >
+          {{- .Title -}}
+        </h1>
+      </div>
+    </header>
+  {{ end }}
+
+
+  <section class="bg-white font-sans">
+    {{ if or (.Content) (.Page.Params.subhed) }}
+      <div
+        class="mx-auto max-w-2xl px-5 pb-10 text-lg font-medium md:px-0 lg:px-0"
+      >
+        {{ with .Page.Params.subhed }}
+          <h2 class="mb-5 text-5xl font-black uppercase">{{ . }}</h2>
+        {{ end }}
+        {{ with .Content }}
+          <div class="article-content">
+            {{ . }}
+          </div>
+        {{ end }}
+      </div>
+    {{ end }}
+
+    {{ range .Params.blocks }}
+      <div
+        data-ga-category="blocks"
+        class="w-full"
+        {{ with .id }}id="{{ . }}"{{ end }}
+      >
+        {{ partial "blocks/block" (dict
+          "Page" $
+          "block" .
+          )
+        }}
+      </div>
+    {{ end }}
+  </section>
+{{ end }}
+
+{{ define "before-footer" }}
+  {{ with .Page.RenderString (.Param "donate") }}
+    <div class="bg-white font-sans">
+      {{ . }}
+    </div>
+  {{ else }}
+    {{ partialCached "tw/promo-footer.html" (dict
+      "wrapperClass" "bg-white pt-2 pb-14 hidden")
+    }}
+  {{ end }}
+{{ end }}

--- a/layouts/partials/blocks/content.html
+++ b/layouts/partials/blocks/content.html
@@ -1,0 +1,22 @@
+{{ with .block }}
+  <section class="bg-white font-sans">
+    <div
+      class="mx-auto max-w-2xl px-5 pb-10 text-lg font-medium md:px-0 lg:px-0"
+    >
+      {{ with .hed }}
+        <header class="bg-white pb-4 pt-8 text-black">
+          <h2
+            class="font-sans text-3xl font-bold leading-none text-black sm:text-4xl lg:text-5xl"
+          >
+            {{ . }}
+          </h2>
+        </header>
+      {{ end }}
+      {{ with .content }}
+        <div class="article-content">
+          {{ page.RenderString . }}
+        </div>
+      {{ end }}
+    </div>
+  </section>
+{{ end }}

--- a/layouts/partials/blocks/credits.html
+++ b/layouts/partials/blocks/credits.html
@@ -1,0 +1,14 @@
+{{ with .block }}
+  <section class="bg-white p-6" id="credits" data-ga-category="credits">
+    <div class="mx-auto flex max-w-2xl flex-col flex-wrap py-12 md:flex-row">
+      <h2
+        class="w-full border-b border-black font-sans text-2xl font-extrabold capitalize leading-tight tracking-wide md:text-3xl"
+      >
+        Credits
+      </h2>
+      <div class="mt-6 flex flex-1 flex-col gap-6">
+        {{ page.RenderString .credits }}
+      </div>
+    </div>
+  </section>
+{{ end }}

--- a/layouts/partials/blocks/donate-slim.html
+++ b/layouts/partials/blocks/donate-slim.html
@@ -1,0 +1,7 @@
+{{ $hed := .hed | default "Did this tool help you? Support Spotlight PA's nonprofit, nonpartisan journalism." }}
+
+{{ partial "tw/donate-slim" (dict
+  "donateHed" $hed
+  "donateCta" "Donate"
+  "donateUrl" "/donate/" )
+}}

--- a/layouts/partials/blocks/opioid-quiz-key.html
+++ b/layouts/partials/blocks/opioid-quiz-key.html
@@ -1,0 +1,50 @@
+{{ with .block }}
+  <div
+    x-data="{ active: null }"
+    class="mx-auto max-w-2xl space-y-4 px-5 pb-12 pt-6 lg:px-0"
+  >
+    <h2 class="leading-tight; mb-4 text-3xl font-bold">
+      {{ .hed }}
+    </h2>
+    <p
+      class="mt-2 text-pretty font-sans text-dek sm:text-base sm:leading-relaxed md:text-lg lg:text-xl"
+    >
+      {{ .dek }}
+    </p>
+    {{ range .answers }}
+      <div
+        x-data="{
+          id: $id('q-and-a'),
+          get expanded() {
+              return this.active === this.id
+          },
+          set expanded(value) {
+              this.active = value ? this.id : null
+          },
+        }"
+        :id="id"
+        role="region"
+      >
+        <h2 class="mb-4 font-sans text-2xl font-extrabold leading-tight">
+          <button
+            @click="expanded = !expanded"
+            :aria-expanded="expanded"
+            class="flex w-full items-center justify-between py-4 text-left text-xl font-bold"
+          >
+            <span class="w-full">{{ .hed }}</span>
+            <span x-show="expanded" aria-hidden="true" class="ml-4"
+              >&minus;</span
+            >
+            <span x-show="!expanded" aria-hidden="true" class="ml-4"
+              >&plus;</span
+            >
+          </button>
+        </h2>
+
+        <div x-show="expanded" x-collapse class="article-content mb-6 pl-0">
+          {{ page.RenderString .body }}
+        </div>
+      </div>
+    {{ end }}
+  </div>
+{{ end }}

--- a/layouts/partials/blocks/opioid-quiz-results.html
+++ b/layouts/partials/blocks/opioid-quiz-results.html
@@ -1,0 +1,60 @@
+{{ with .block }}
+  <div class="mx-auto max-w-2xl px-5 md:px-0">
+    <div
+      x-data="{
+      agree: 0,
+      disagree: 0
+    }"
+      x-init="
+      let params = new URL(window.location).searchParams;
+      agree = +params.get('agree');
+      disagree = +params.get('disagree');
+    "
+    >
+      <div
+        class="mx-auto flex max-w-2xl flex-wrap items-center justify-stretch gap-3 px-5 pb-3 md:px-0 lg:px-0"
+      >
+        <div class="flex w-1/2 flex-col justify-end">
+          <h3 class="text-xl font-bold leading-none">Agree</h3>
+          <p class="mt-1 text-base leading-tight text-g-8">
+            Your choices agree with the opiod trust on
+            <span
+              x-text="
+              agree === 0 ? 'no questions.' :
+              agree === 1 ? 'one question.' :
+              `${agree} questions.`
+              "
+            ></span>
+          </p>
+        </div>
+        <div class="flex h-6 w-full max-w-[248px]">
+          <template x-for="_ in new Array( agree ).fill(null)">
+            <span class="mr-1 block h-6 w-6 rounded-sm bg-g-3 last:mr-0"></span>
+          </template>
+        </div>
+      </div>
+      <div
+        class="mx-auto flex max-w-2xl flex-wrap items-center justify-stretch gap-3 px-5 pb-3 md:px-0 lg:px-0"
+      >
+        <div class="flex w-1/2 flex-col justify-end">
+          <h3 class="text-xl font-bold leading-none">Disagree</h3>
+          <p class="mt-1 text-base leading-tight text-g-8">
+            Your choices disagree with the opiod trust on
+            <span
+              x-text="
+              disagree === 0 ? 'no questions.' :
+              disagree === 1 ? 'one question.' :
+              `${disagree} questions.`
+              "
+            ></span>
+          </p>
+        </div>
+        <div class="flex h-6 w-full max-w-[248px]">
+          <template x-for="_ in new Array( disagree ).fill(null)">
+            <span class="mr-1 block h-6 w-6 rounded-sm bg-g-3 last:mr-0"></span>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+{{ end }}

--- a/layouts/partials/blocks/show-results-end.html
+++ b/layouts/partials/blocks/show-results-end.html
@@ -1,0 +1,1 @@
+{{ `</div>` | safeHTML }}

--- a/layouts/partials/blocks/show-results-start.html
+++ b/layouts/partials/blocks/show-results-start.html
@@ -1,0 +1,5 @@
+{{ `</div><div
+  x-data="{ showResults: !!window.location.search.match(/show_results/) }"
+  x-show="showResults"
+  ><div>` | safeHTML
+}}

--- a/layouts/partials/blocks/typeform-button.html
+++ b/layouts/partials/blocks/typeform-button.html
@@ -1,0 +1,5 @@
+{{ with .block }}
+  <div class="flex justify-center">
+    {{ partial "thirdparty/typeform.html" (dict "id" .typeformid) }}
+  </div>
+{{ end }}

--- a/src/utils/google-analytics.js
+++ b/src/utils/google-analytics.js
@@ -83,7 +83,9 @@ export function addGAListeners() {
       if (!el) return;
 
       let isInternal =
-        el.host === window.location.host || el.host.match(/spotlightpa\.org$/);
+        el.host === window.location.host ||
+        el.host.match(/spotlightpa\.org$/) ||
+        (el.protocol !== "http:" && el.protocol !== "https:");
 
       // Open external links in new window
       if (!isInternal) {


### PR DESCRIPTION
This involved cloning the existing quiz template and then breaking it down into a series of blocks to remix and adding a new template that just displays blocks in order.