### PR TITLE
Wisepops: Allow pop ups on the Terms of Service and Privacy pages

### DIFF
--- a/content/about/about-privacy.md
+++ b/content/about/about-privacy.md
@@ -2,6 +2,7 @@
 title = "Privacy Policy"
 description = "Your privacy is important to us at Spotlight PA and its affiliates and subsidiaries."
 url = "/about/privacy/"
+modal-exclude = false
 +++
 ## Spotlight PA Privacy Policy
 

--- a/content/about/about-tos.md
+++ b/content/about/about-tos.md
@@ -2,6 +2,7 @@
 title = "Terms of Service"
 description = "Please Read These Terms Of Service Carefully Before Using This Website."
 url = "/about/terms/"
+modal-exclude = false
 +++
 
 ## Spotlight PA Terms of Service


### PR DESCRIPTION
There is a cascade value that disables pop ups on the about parent page.