### PR TITLE
social-buttons.html: Add Bluesky button

### DIFF
--- a/layouts/partials/featured/social-buttons.html
+++ b/layouts/partials/featured/social-buttons.html
@@ -40,6 +40,18 @@
       </svg>
     </span>
   </a>
+  <a
+    class="{{ $btnClass }} hover:bg-bluesky-blue hover:text-white"
+    href="https://bsky.app/intent/compose?text={{ .LinkTitle }}{{ `— via @spotlightpa.org ` }}{{ .Permalink }}"
+    data-ga-category="bluesky"
+    title="Post about this page on Bluesky"
+  >
+    <span class="m-auto">
+      <svg class="h-6 w-6 fill-current">
+        {{ partial "helper/svg.html" "bluesky" }}
+      </svg>
+    </span>
+  </a>
   <button
     class="{{ $btnClass }} hover:bg-orange hover:text-white"
     data-share-text="Read “{{ .LinkTitle }}” from Spotlight PA"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,6 +40,7 @@ module.exports = {
       beige: "#f4f1ee",
       "tw-blue": "#99d9f1",
       "fb-blue": "#009edb",
+      "bluesky-blue": "#1185fe",
       orange: "#ff6c36",
       green: "#78bc20",
       yellow: {


### PR DESCRIPTION
This add a Bluesky button to template articles.

Before hover:

<img width="285" alt="image" src="https://github.com/user-attachments/assets/08648913-8864-4697-8549-11d2ff3281ff" />

On hover:

<img width="304" alt="image" src="https://github.com/user-attachments/assets/e2c96624-9d56-41e8-92f2-a02054980e54" />
