### PR TITLE
shortcodes/datawrapper: Use Web Component, not iframe

### DIFF
--- a/layouts/shortcodes/datawrapper.html
+++ b/layouts/shortcodes/datawrapper.html
@@ -1,30 +1,18 @@
 {{ $src := .Get "src" | htmlUnescape }}
 {{ $height := .Get "height" | htmlUnescape }}
+{{ $id := partial "helper/new-id" . }}
 
 
-<iframe
-  aria-label="Chart"
-  src="{{ $src }}"
-  scrolling="no"
-  frameborder="0"
-  class="my-8 w-0 min-w-full border-none"
-  height="{{ $height }}"
-  data-external="1"
-></iframe>
-
-{{ if page.Scratch.Get "has-datawrapper" | not }}
-  {{ page.Scratch.Set "has-datawrapper" true }}
-  <script type="module">
-    window.addEventListener("message", function (a) {
-      if (void 0 !== a.data["datawrapper-height"]) {
-        var e = document.querySelectorAll("iframe");
-        for (var t in a.data["datawrapper-height"])
-          for (var r = 0; r < e.length; r++)
-            if (e[r].contentWindow === a.source) {
-              var i = a.data["datawrapper-height"][t] + "px";
-              e[r].style.height = i;
-            }
-      }
-    });
-  </script>
-{{ end }}
+<div class="my-8">
+  <div style="min-height: {{ $height }}px;" id="{{ $id }}">
+    <script
+      defer
+      src="{{ urls.JoinPath $src `embed.js` }}"
+      charset="utf-8"
+      data-target="#{{ $id }}"
+    ></script>
+    <noscript>
+      <img src="{{ urls.JoinPath $src `full.png` }}" alt="" />
+    </noscript>
+  </div>
+</div>


### PR DESCRIPTION
See https://www.datawrapper.de/blog/web-component-embedding

I'm also making a change to Almanack so we can intercept Web Component embeds from Datawrapper and turn them into `{{<datawrapper>}}` shortcodes.