### PR TITLE
newsletter-topper: Use Tailwind sub-selector for subhead

### DIFF
--- a/content/newsletters/gooddayberks/_index.md
+++ b/content/newsletters/gooddayberks/_index.md
@@ -3,9 +3,7 @@ layout = "individual-newsletter"
 max-width = "715px"
 
 title = "Local news, fresh daily"
-white-subhead-first = "Sign up for "
-yellow-subhead = "Good Day, Berks"
-white-subhead-second = " - Spotlight PA’s free daily newsletter for Berks County"
+subhead = "Sign up for **Good Day, Berks** — Spotlight PA’s free daily newsletter for Berks County"
 
 deck = "Your daily dose of Berks County essentials"
 

--- a/content/newsletters/howwecare/_index.md
+++ b/content/newsletters/howwecare/_index.md
@@ -3,9 +3,7 @@ layout = "individual-newsletter"
 max-width = "prose"
 
 title = "Sharing stories of essential work"
-white-subhead-first = "Sign up for "
-yellow-subhead = "How We Care"
-white-subhead-second = ", a free weekly newsletter on the state of caregiving and health in PA"
+subhead = "Sign up for **How We Care**, a free weekly newsletter on the state of caregiving and health in PA"
 
 bullets = [
   "Delivered straight to your inbox every Tuesday",

--- a/content/newsletters/investigator/_index.md
+++ b/content/newsletters/investigator/_index.md
@@ -3,9 +3,7 @@ layout = "individual-newsletter"
 max-width = "705px"
 
 title = "Go behind the scenes"
-white-subhead-first = "Sign up for "
-yellow-subhead = "The Investigator"
-white-subhead-second = " for exclusive looks at our reporting"
+subhead = "Sign up for **The Investigator** for exclusive looks at our reporting"
 deck = "Learn more about our unique investigative journalism that gets results"
 
 bullets = [

--- a/content/newsletters/palocal/_index.md
+++ b/content/newsletters/palocal/_index.md
@@ -3,9 +3,7 @@ layout = "individual-newsletter"
 max-width = "750px"
 
 title = "Good news for a change"
-white-subhead-first = "Sign up for "
-yellow-subhead = "PA Local"
-white-subhead-second = " for a fresh, positive look at our great state"
+subhead = "Sign up for **PA Local** for a fresh, positive look at our great state"
 
 deck = "Get to know Pennsylvania a little better and celebrate the good"
 

--- a/content/newsletters/papost/_index.md
+++ b/content/newsletters/papost/_index.md
@@ -3,9 +3,7 @@ layout = "individual-newsletter"
 max-width = "prose"
 
 title = "Your guide to PA"
-white-subhead-first = "Sign up for "
-yellow-subhead = "PA Post"
-white-subhead-second = ", Spotlight PA’s free daily newsletter"
+subhead = "Sign up for **PA Post**, Spotlight PA’s free daily newsletter"
 deck = "Get the day’s most important statewide news from Spotlight PA and beyond"
 
 bullets = [

--- a/content/newsletters/pennstatealert/_index.md
+++ b/content/newsletters/pennstatealert/_index.md
@@ -3,10 +3,7 @@ layout = "individual-newsletter"
 max-width = "prose"
 
 title = "Get the latest"
-white-subhead-first = "Sign up for "
-yellow-subhead = "Penn State Alerts"
-white-subhead-second = ""
-
+subhead = "Sign up for **Penn State Alerts**"
 deck = "Be the first to know about our coverage of Penn State University"
 
 bullets = [

--- a/content/newsletters/talkofthetown/_index.md
+++ b/content/newsletters/talkofthetown/_index.md
@@ -3,9 +3,7 @@ layout = "individual-newsletter"
 max-width = "730px"
 
 title = "News for north-central PA"
-white-subhead-first = "Sign up for "
-yellow-subhead = "Talk of the Town"
-white-subhead-second = " for essential news from our State College bureau"
+subhead = "Sign up for **Talk of the Town** for essential news from our State College bureau"
 
 deck = "The news that matters to your community — from the PA Wilds to Happy Valley"
 

--- a/layouts/partials/blocks/newsletter-topper.html
+++ b/layouts/partials/blocks/newsletter-topper.html
@@ -34,15 +34,10 @@
           {{ .Title }}
         </h1>
 
-        <h2 class="mb-4 text-lg font-semibold text-white">
-          <span>
-            {{- $first := .Param "white-subhead-first" | default "" -}}
-            {{- $yellow := .Param "yellow-subhead" | default "" -}}
-            {{- $second := .Param "white-subhead-second" | default "" -}}
-
-            {{- $first -}}<span class="text-yellow">{{- $yellow -}}</span
-            >{{- $second -}}
-          </span>
+        <h2
+          class="mb-4 text-lg font-semibold text-white [&_strong]:text-yellow"
+        >
+          {{ .Param "subhead" | markdownify }}
         </h2>
 
         <p class="text-white">


### PR DESCRIPTION
Simplify the subhead on newsletter-topper by styling `strong` tags.