### PR TITLE
Revert "Flourish shortcode: Simpler logic"

### DIFF
--- a/layouts/shortcodes/flourish.html
+++ b/layouts/shortcodes/flourish.html
@@ -6,7 +6,8 @@
   data-src="{{ $src }}"
 ></div>
 
-{{ if eq .Ordinal 0 }}
+{{ if page.Scratch.Get "has-flourish" | not }}
+  {{ page.Scratch.Set "has-flourish" true }}
   <script
     defer
     src="https://public.flourish.studio/resources/embed.js"


### PR DESCRIPTION
This reverts commit 98fa8e467efcffed70ac182ae9caffa6ea89ddce.

It turns out .Ordinal counts all shortcodes, not just shortcodes of the same tag.