### PR TITLE
image-block: Fix image on article page

### DIFF
--- a/layouts/_partials/tw/image-block.html
+++ b/layouts/_partials/tw/image-block.html
@@ -11,7 +11,7 @@
 {{ $shadow := cond (.shadow|not|not) "shadow-sm" "" }}
 {{ $creditClass := .creditClass | default "mt-1 w-full px-1 text-right font-sans text-xs uppercase leading-tight text-credit" }}
 {{ $containerClass := .containerClass | default "relative w-full overflow-clip group flex items-center justify-center bg-g-3" }}
-{{ $wrapperClass := .wrapperClass | default "block" }}
+{{ $wrapperClass := .wrapperClass | default "block w-full" }}
 {{ $pictureClass := .pictureClass | default "flex" }}
 {{ $captionClass := .captionClass | default `mt-6 font-sans leading-tight text-g-8` }}
 {{ $inlineCredit := .inlineCredit }}


### PR DESCRIPTION
Making the container display flex made the inner item no longer take up the full width by default.