### PR TITLE
tag/picture.html: Add default sizeHint

### DIFF
--- a/layouts/_partials/tag/picture.html
+++ b/layouts/_partials/tag/picture.html
@@ -2,7 +2,11 @@
   <source
     type="image/webp"
     srcset="{{ .srcset }}"
-    {{ with .sizeHint }}sizes="{{ . }}"{{ end }}
+    {{ with .sizeHint }}
+      sizes="auto, {{ . }}"
+    {{ else }}
+      sizes="auto"
+    {{ end }}
   />
   <img
     itemprop="contentUrl"


### PR DESCRIPTION
A minor possible performance boost. See https://piccalil.li/blog/the-end-of-responsive-images/ for an explanation.